### PR TITLE
Binding getSignals method for components

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 module.exports = function(controller) {
   return {
+    getSignals: function(path) {
+      return controller.getSignals(path)
+    },
     connectCerebral: function (statePaths, signalPaths) {
       var tag = this
 


### PR DESCRIPTION
For convenience, I added a binding for `getSignals` so it can be used outside of the `connectCerebral` method.

Alternatively, we could just bind the actual controller object for convenience.
